### PR TITLE
Scrape all future terms exposed by Banner, resolves #56

### DIFF
--- a/backend/internal/api/handlers.go
+++ b/backend/internal/api/handlers.go
@@ -282,7 +282,10 @@ func (h *Handlers) GetTerms(c *gin.Context) {
 }
 
 // determineCurrentTerm selects the best default term for the frontend.
-// Prefers pre-registration (upcoming term), then active registration, then most recent.
+// Prefers the most recent term in active registration; otherwise the soonest
+// upcoming pre-registration term; otherwise the most recent term overall.
+//
+// `terms` is sorted by code DESC (newest first).
 func determineCurrentTerm(terms []*store.Term) string {
 	if len(terms) == 0 {
 		return ""
@@ -290,23 +293,23 @@ func determineCurrentTerm(terms []*store.Term) string {
 
 	now := time.Now()
 
-	// Find the first term in pre-registration (registration opening soon)
 	for _, t := range terms {
-		phase := jobs.GetTermPhase(t.Code, now)
-		if phase == jobs.PhasePreRegistration {
+		if jobs.GetTermPhase(t.Code, now) == jobs.PhaseActiveRegistration {
 			return t.Code
 		}
 	}
 
-	// Fall back to active registration (current term still registering)
+	// Soonest pre-reg term = last one in DESC-sorted slice that's pre-reg.
+	soonestPreReg := ""
 	for _, t := range terms {
-		phase := jobs.GetTermPhase(t.Code, now)
-		if phase == jobs.PhaseActiveRegistration {
-			return t.Code
+		if jobs.GetTermPhase(t.Code, now) == jobs.PhasePreRegistration {
+			soonestPreReg = t.Code
 		}
 	}
+	if soonestPreReg != "" {
+		return soonestPreReg
+	}
 
-	// If nothing matches, return the most recent term
 	return terms[0].Code
 }
 

--- a/backend/internal/api/handlers.go
+++ b/backend/internal/api/handlers.go
@@ -293,17 +293,13 @@ func determineCurrentTerm(terms []*store.Term) string {
 
 	now := time.Now()
 
+	var soonestPreReg string
 	for _, t := range terms {
-		if jobs.GetTermPhase(t.Code, now) == jobs.PhaseActiveRegistration {
+		switch jobs.GetTermPhase(t.Code, now) {
+		case jobs.PhaseActiveRegistration:
 			return t.Code
-		}
-	}
-
-	// Soonest pre-reg term = last one in DESC-sorted slice that's pre-reg.
-	soonestPreReg := ""
-	for _, t := range terms {
-		if jobs.GetTermPhase(t.Code, now) == jobs.PhasePreRegistration {
-			soonestPreReg = t.Code
+		case jobs.PhasePreRegistration:
+			soonestPreReg = t.Code // keep overwriting; DESC-sorted, so last wins
 		}
 	}
 	if soonestPreReg != "" {

--- a/backend/internal/jobs/term.go
+++ b/backend/internal/jobs/term.go
@@ -13,7 +13,6 @@ const (
 	PhasePast               TermPhase = iota // Term has ended
 	PhasePreRegistration                     // Registration not yet open (scrape daily)
 	PhaseActiveRegistration                  // Registration open or term in progress (scrape frequently)
-	PhaseFuture                              // Too far in the future to scrape
 )
 
 func (p TermPhase) String() string {
@@ -24,8 +23,6 @@ func (p TermPhase) String() string {
 		return "pre-registration"
 	case PhaseActiveRegistration:
 		return "active-registration"
-	case PhaseFuture:
-		return "future"
 	default:
 		return "unknown"
 	}
@@ -78,6 +75,9 @@ func MakeTermCode(year, quarter int) string {
 //   - Fall: Sep 24 - Dec 12
 //
 // Registration is estimated to open 40 days before term start.
+// Any term not yet in active registration is treated as pre-registration so
+// the daily job scrapes every future term Banner exposes — Banner controls
+// how far ahead terms are surfaced.
 // TODO(#37): Scrape actual registration dates from Banner for precise detection.
 func GetTermPhase(termCode string, now time.Time) TermPhase {
 	year, quarter, err := ParseTermCode(termCode)
@@ -94,12 +94,7 @@ func GetTermPhase(termCode string, now time.Time) TermPhase {
 	if now.After(regStart) {
 		return PhaseActiveRegistration
 	}
-	// Pre-registration: within 60 days before registration opens
-	preRegStart := regStart.AddDate(0, 0, -60)
-	if now.After(preRegStart) {
-		return PhasePreRegistration
-	}
-	return PhaseFuture
+	return PhasePreRegistration
 }
 
 // getTermDates returns approximate start and end dates for a term.

--- a/backend/internal/jobs/term_test.go
+++ b/backend/internal/jobs/term_test.go
@@ -93,10 +93,16 @@ func TestGetTermPhase(t *testing.T) {
 			wantPhase: PhasePreRegistration,
 		},
 		{
-			name:      "Winter future",
+			name:      "Winter far before registration still pre-registration",
 			termCode:  "202510",
 			now:       time.Date(2024, 9, 1, 0, 0, 0, 0, time.Local),
-			wantPhase: PhaseFuture,
+			wantPhase: PhasePreRegistration,
+		},
+		{
+			name:      "Fall many months before registration still pre-registration",
+			termCode:  "202640",
+			now:       time.Date(2026, 5, 15, 0, 0, 0, 0, time.Local),
+			wantPhase: PhasePreRegistration,
 		},
 
 		// Spring 2025: Apr 1 - Jun 12, reg opens Feb 20 (40 days before)
@@ -248,7 +254,6 @@ func TestTermPhaseString(t *testing.T) {
 		{PhasePast, "past"},
 		{PhasePreRegistration, "pre-registration"},
 		{PhaseActiveRegistration, "active-registration"},
-		{PhaseFuture, "future"},
 		{TermPhase(99), "unknown"},
 	}
 


### PR DESCRIPTION
## Summary

- Fix #56: 2026-2027 quarters appearing in the term dropdown but showing no subjects/sections because `GetTermPhase` returned `PhaseFuture` for terms more than ~100 days out, and no scrape job handled `PhaseFuture`.
- Collapse `PhaseFuture` into `PhasePreRegistration` so `DailyScrapeJob` picks up every future term Banner exposes — Banner controls how far ahead the horizon is.
- Rework `determineCurrentTerm`: since pre-reg now matches more terms, the old "first DESC pre-reg" picked the furthest-future term as the default. New behavior: prefer most recent active-reg term; otherwise the soonest upcoming pre-reg term; otherwise the most recent term. Collapsed into a single switch-based pass.

## Test plan

- [x] `go test ./internal/jobs/... ./internal/api/...` passes
- [ ] After deploy + server restart, verify Fall 2026 / Winter 2027 / Spring 2027 populate `last_scraped_at` and surface subjects in the UI
- [ ] Confirm the default selected term on `/api/terms` is sensible for current date (likely Summer 2026 while its active reg is open, then Fall 2026 after)
- [ ] Tail logs after restart for `ScrapeTerm` failures on far-future terms