### PR TITLE
Show open seats instead of enrollment in section cards

### DIFF
--- a/frontend/src/components/schedule/SectionCard.tsx
+++ b/frontend/src/components/schedule/SectionCard.tsx
@@ -89,11 +89,13 @@ function formatLocation(meeting: MeetingTime): string | null {
 }
 
 function formatEnrollment(section: HydratedSection): string {
-  const { enrollment, maxEnrollment, waitCount } = section
+  // Banner reports seatsAvailable as open (remaining) seats; show open/capacity
+  // to match what students see in Banner (issue #53).
+  const { seatsAvailable, maxEnrollment, waitCount } = section
   if (waitCount > 0) {
-    return `${enrollment}/${maxEnrollment} seats (${waitCount} waitlist)`
+    return `${seatsAvailable}/${maxEnrollment} seats open (${waitCount} waitlist)`
   }
-  return `${enrollment}/${maxEnrollment} seats`
+  return `${seatsAvailable}/${maxEnrollment} seats open`
 }
 
 export const SectionCard = memo(function SectionCard({


### PR DESCRIPTION
Banner reports `seatsAvailable` as remaining/open seats. Section cards were showing `enrollment/maxEnrollment` (filled/capacity), which reads backwards. Swap to `seatsAvailable/maxEnrollment` labeled "open" to match what students see in Banner.

Typecheck clean, 118 frontend tests pass, no new lint.

Resolves #53