### PR TITLE
Bump frontend to v2.1.3 + version-bump reminder in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,7 @@ Schedule Optimizer is a course scheduling tool for WWU students. `main` holds th
 - **Self-review non-trivial work.** After a non-trivial change, spin off an agent for an unbiased code review that checks: architecture alignment (does this belong here?), file/function lengths (keep functions focused, split large files), scope creep (only what was requested), and whether tests exercise real code paths rather than mocking unrealistic scenarios.
 - **Course-centric, not term-centric.** Data structures should support cross-term search. Organize by unique course ID, not term→CRN hierarchy.
 - **Git workflow.** Work on feature branches and commit freely as you go. Open PRs against `main` only after checking in first — the user squash-merges them. Don't add AI attribution or co-author trailers to commits.
+- **Bump the version.** Don't forget to bump `frontend/package.json` `version` (rendered in the footer) with each piece of work — patch for fixes/small changes, minor for features. Fold the bump into the feature branch so shipped work never goes out with a stale version.
 
 ## Prerequisites
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "2.1.0",
+  "version": "2.1.3",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Bumps `frontend/package.json` version 2.1.0 -> 2.1.3 (catch-up for the seat-count #53 and og:image #49 work already shipped; footer renders this). Adds a CLAUDE.md note under Development Philosophy to bump the version with each piece of work going forward, folded into the feature branch.